### PR TITLE
backport SCIP time limit removal

### DIFF
--- a/aldy/lpinterface.py
+++ b/aldy/lpinterface.py
@@ -193,7 +193,7 @@ class SCIP(Gurobi):
 			'minimize' if method == 'min' else 'maximize'
 		)
 		# self.model.params.timeLimit = 60
-		self.model.setRealParam('limits/time', 120)
+		self.model.setRealParam('limits/time', 60*60)
 		self.model.hideOutput()
 		self.model.optimize()
 


### PR DESCRIPTION
With hybrid allele calling, I'm seeing diplotype calls that are negatively impacted by a time limit in the ILP solver library, so to effectively remove this time limit, I'm backporting a change described here:

https://github.com/inumanag/aldy/commit/67fd0678e69cde2eee3d425a864cc72d9061d1a5#diff-b2dd2e65f81ae45c5549fbaa605af628R198