### PR TITLE
10 min time limit to reduce memory usage

### DIFF
--- a/aldy/lpinterface.py
+++ b/aldy/lpinterface.py
@@ -193,7 +193,7 @@ class SCIP(Gurobi):
 			'minimize' if method == 'min' else 'maximize'
 		)
 		# self.model.params.timeLimit = 60
-		self.model.setRealParam('limits/time', 60*60)
+		self.model.setRealParam('limits/time', 10*60)
 		self.model.hideOutput()
 		self.model.optimize()
 


### PR DESCRIPTION
Turns out aldy starts using lots of memory if the solver continues for too long (5-10 gigs per process before I killed the job). Since the refining step can take a lot of time and we don't care as much about minor alleles, reduce the time limit to 10 minutes, which bounds the process to about 1-2 gigs.