### PR TITLE
Remove `CYP2C19 *11` from configuration file

### DIFF
--- a/aldy/resources/genes/cyp2c19.yml
+++ b/aldy/resources/genes/cyp2c19.yml
@@ -365,15 +365,6 @@ alleles:
       - [5124, C>T, rs17885098]
       - [24178, C>T, rs6413438, P227L]
       - [85186, A>G, rs3758581, I331V]
-  CYP2C19*11.001:
-    pharmvar: https://www.pharmvar.org/haplotype/100
-    activity: normal function
-    label: CYP2C19*11
-    evidence: M
-    mutations:
-      - [5124, C>T, rs17885098]
-      - [17827, G>A, rs58973490, R150H]
-      - [85186, A>G, rs3758581, I331V]
   CYP2C19*12.001:
     pharmvar: https://www.pharmvar.org/haplotype/90
     activity: uncertain function


### PR DESCRIPTION
[BIOINF-7251] Test dropping `CYP2C19 *11` to see if we recover `*2` and `*17` 
calls that were previously discordant


[BIOINF-7251]: https://getcolor.atlassian.net/browse/BIOINF-7251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ