### PR TITLE
[BIOINF] Remove sierra_leone from G6PD config

### DIFF
--- a/aldy/resources/genes/g6pd.yml
+++ b/aldy/resources/genes/g6pd.yml
@@ -95,12 +95,6 @@ alleles:
     activity: III/Deficient
     mutations:
       - [18977, G>C, rs137852318, D282Y]
-  G6PD*sierra_leone:
-    label: Sierra Leone
-    activity: Not reported/Unknown
-    mutations:
-      - [17231, G>A, rs181277621, R104H]
-      - [17296, A>G, rs1050829, N126D]
   G6PD*ube_konan:
     label: Ube Konan
     activity: III/Deficient


### PR DESCRIPTION
`sierra_leone` is not reportable and should not be in the config to make liek 
easier.
